### PR TITLE
Add InfraScan security audit to CI/CD

### DIFF
--- a/.github/workflows/infrascan.yml
+++ b/.github/workflows/infrascan.yml
@@ -1,0 +1,45 @@
+name: InfraScan Audit
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    types: [ opened, reopened, synchronize ]
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  infrascan:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Run InfraScan
+        uses: soldevelo/infrascan@v1.0.5
+        with:
+          scanner: comprehensive
+          format: html
+          out: infrascan-report.html
+
+      - name: Upload InfraScan Report
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: infrascan-report
+          path: infrascan-report.html
+          retention-days: 30
+
+      - name: Comment PR with Results
+        if: github.event_name == 'pull_request' && always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '🔍 InfraScan audit completed. [View full report in artifacts](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})'
+            })

--- a/.github/workflows/infrascan.yml
+++ b/.github/workflows/infrascan.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run InfraScan
-        uses: soldevelo/infrascan@v1.0.5
+        uses: soldevelo/infrascan@v1.0.6
         with:
           scanner: comprehensive
           format: html


### PR DESCRIPTION
I ran a manual web scan of this repository using **InfraScan**, and the results showed a lot of room for improvement: https://infrascan.soldevelo.com/?scan_id=6ae8c26c-e0ce-45ad-b91a-5f8be1509304

To help manage this, I’m adding an automated security audit to the pipeline.

It’s an open-source infrastructure auditor that scans Docker images, IaC, and cloud setups for security vulnerabilities and cost optimizations.
Changes in this PR:

    Workflow: Added .github/workflows/infrascan.yml. It runs a comprehensive scan on every push to master and on all Pull Requests.

    Reports: Results are uploaded as artifacts, and a summary link is automatically posted as a PR comment.

Integrating this now will help us track and patch these vulnerabilities (most already have fixes available) and ensure no new security risks are introduced.