### PR TITLE
Add ApplicationSet to deploy redis in backbone namespace for hcm-demo…

### DIFF
--- a/config-as-code/helm/charts/argo-cd/backbone/backbone-app-set-hcm-demo.yaml
+++ b/config-as-code/helm/charts/argo-cd/backbone/backbone-app-set-hcm-demo.yaml
@@ -1,0 +1,50 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: hcm-demo-backbone-appset
+  namespace: argocd
+spec:
+  generators:
+    - list:
+        elements:
+          - name: redis
+
+  template:
+    metadata:
+      name: 'backbone-{{name}}'
+
+    spec:
+      project: egov-project
+
+      source:
+        repoURL: git@github.com:egovernments/health-campaign-devops.git
+        targetRevision: azure-install-hcm-demo
+        path: config-as-code/helm/charts/backbone-services/{{name}}
+        helm:
+          valueFiles:
+            - values.yaml
+            - ../../../../environments/hcm-demo-azure.yaml
+
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: backbone
+
+      ignoreDifferences:
+        - group: apps
+          kind: Deployment
+          jsonPointers:
+            - /spec/replicas
+
+      syncPolicy:
+        automated:
+          prune: false
+          selfHeal: true
+        syncOptions:
+          - ApplyOutOfSyncOnly=true
+          - ServerSideApply=true
+        retry:
+          limit: 10
+          backoff:
+            duration: 5s
+            factor: 2
+            maxDuration: 3m0s


### PR DESCRIPTION
…-azure

Gateway pods fail with unresolved DNS for redis.backbone since no ApplicationSet in this repo deployed backbone-services for the hcm-demo-azure environment.